### PR TITLE
Fixing file extensions so examples work

### DIFF
--- a/src/TanaAPIClient.ts
+++ b/src/TanaAPIClient.ts
@@ -1,5 +1,5 @@
-import { attrDefTemplateId, coreTemplateId } from './types/constants';
-import { APIField, APINode, APIPlainNode, TanaNode } from './types/types';
+import { attrDefTemplateId, coreTemplateId } from './types/constants.js';
+import { APIField, APINode, APIPlainNode, TanaNode } from './types/types.js';
 import fetch from 'node-fetch';
 import { readFileSync } from 'fs';
 

--- a/src/examples/books.ts
+++ b/src/examples/books.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
-import { TanaAPIHelper } from '../TanaAPIClient';
-import { waitForEnter } from '../utils';
+import { TanaAPIHelper } from '../TanaAPIClient.js';
+import { waitForEnter } from '../utils.js';
 
 const token = process.env.TANA_TOKEN || '';
 


### PR DESCRIPTION
I tried running the code examples using `TANA_TOKEN=token yarn run example:books ` and received the error that modules were not found. 

I examined the code and realized that the file extensions were absent from the import scripts (e.g. `.js`). I added these and tested it and everything works now. 